### PR TITLE
fix(blog): Clarify Neo4j and MCP content

### DIFF
--- a/src/contents/posts/en/beyond-basic-rag-mcp-graphiti.mdx
+++ b/src/contents/posts/en/beyond-basic-rag-mcp-graphiti.mdx
@@ -28,15 +28,15 @@ Basic RAG is like a librarian who can find any book you ask for but forgets who 
 The [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) is a game-changer. It provides a standardized way for AI models to connect to external data sources and tools.
 
 Instead of hard-coding integrations, MCP allows us to create a plug-and-play ecosystem where an agent can:
-- Query a database.
+- Query a knowledge graph or a specialized database.
 - Read a local file system.
-- Interact with specialized APIs (like Neo4j or Slack).
+- Interact with communication platforms (like Slack) or specialized enterprise APIs.
 
 This turns the AI from a chatbot into an **operator**.
 
 ### Graphiti: The Living Memory Graph
 
-To solve the memory problem, I've been using **Graphiti**. Unlike a flat vector store, Graphiti builds a dynamic knowledge graph (often backed by Neo4j) that evolves as the agent interacts with the world.
+To solve the memory problem, I've been using **Graphiti**. Unlike a flat vector store, Graphiti builds a dynamic knowledge graph (backed by a graph database like **Neo4j**) that evolves as the agent interacts with the world.
 
 When the agent learns something new, it doesn't just store a string of text; it creates nodes and edges. For example: `[Gading] -> (LIKES) -> [Clean Code]`.
 

--- a/src/contents/posts/id/rag-ke-agen-ai-mcp-graphiti.mdx
+++ b/src/contents/posts/id/rag-ke-agen-ai-mcp-graphiti.mdx
@@ -28,15 +28,15 @@ RAG biasa itu kayak pustakawan yang jago nyari buku apa pun yang lu minta, tapi 
 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) itu bener-bener pengubah permainan (*game-changer*). Protokol ini nyediain cara standar buat model AI terhubung ke sumber data eksternal dan tools.
 
 Daripada kita bikin integrasi manual satu-satu (hard-coding), MCP bikin ekosistem yang plug-and-play di mana agen bisa:
-- Query database.
+- Query knowledge graph atau database khusus.
 - Baca file system lokal.
-- Interaksi sama API khusus (kayak Neo4j atau Slack).
+- Interaksi sama platform komunikasi (kayak Slack) atau API khusus lainnya.
 
 Ini ngerubah AI dari sekadar chatbot jadi seorang **operator**.
 
 ### Graphiti: Graf Memori yang "Hidup"
 
-Buat nyelesein masalah memori, gue pakai **Graphiti**. Beda sama vector store yang datar, Graphiti ngebangun graf pengetahuan dinamis (biasanya pakai Neo4j) yang berevolusi tiap kali agen berinteraksi.
+Buat nyelesein masalah memori, gue pakai **Graphiti**. Beda sama vector store yang datar, Graphiti ngebangun graf pengetahuan dinamis (yang didukung oleh graph database kayak **Neo4j**) yang berevolusi tiap kali agen berinteraksi.
 
 Pas agen belajar hal baru, dia gak cuma nyimpen teks; dia bikin "node" dan "edge". Contohnya: `[Gading] -> (SUKA) -> [Clean Code]`.
 


### PR DESCRIPTION
Improved clarity on Neo4j's role as a graph database backing Graphiti and updated MCP examples to be more precise.