### PR TITLE
feat(blog): add homelab architecture post (k8s + lxc)

### DIFF
--- a/src/contents/posts/en/homelab-architecture-k8s-lxc-proxmox.mdx
+++ b/src/contents/posts/en/homelab-architecture-k8s-lxc-proxmox.mdx
@@ -1,25 +1,64 @@
 ---
-title: "Modern Homelab Architecture Design: Integrating K8s & Standalone LXC on Proxmox VE"
+title: "How I Built My Homelab Architecture: From Bare Metal to the Public Internet"
 slug: {
   en: "homelab-architecture-k8s-lxc-proxmox",
   id: "arsitektur-homelab-k8s-lxc-proxmox"
 }
 date: 2026-06-28
-description: "How to combine the flexibility of Kubernetes (K3s) for stateless applications and the native performance of LXC for databases on a single Proxmox VE physical server securely and cleanly."
-keywords: "Homelab, Kubernetes, K3s, LXC, Proxmox, Cloudflare Tunnel, Traefik, IaC, Terraform, DevOps"
+description: "A comprehensive guide to building a self-hosted homelab architecture from physical bare-metal servers, Proxmox virtualization, Kubernetes (K3s) orchestration, to exposing it securely to the public internet."
+keywords: "Homelab, Kubernetes, K3s, LXC, Proxmox, Cloudflare Tunnel, Traefik, IaC, Terraform, DevOps, Bare Metal"
 tags: ["infrastructure", "homelab", "kubernetes", "proxmox", "devops"]
 image: "/media/default-banners/8.jpg"
 ---
 
-Following my previous post on why building a homelab still matters, this time I want to dive deeper into the **latest homelab architecture design** I have implemented.
+Following my previous post on why building a homelab still matters, this time I want to dive deeper into **how I built my latest homelab architecture**—starting from the physical hardware (*bare metal*) to exposing services securely to the public internet.
 
-Many people starting out with a homelab immediately deploy everything inside Kubernetes (K8s), or conversely, deploy everything using loose Docker Compose files on separate VMs/LXCs. Here, I chose a middle-ground approach: a **Hybrid Workload Architecture**—combining the orchestration power of **Kubernetes (K3s)** for *stateless* applications and the *native* performance of **Standalone LXC Containers** for *stateful* services (like databases and storage), all running on a single physical **Proxmox VE** hypervisor.
+Many people starting out with a homelab immediately deploy everything inside Kubernetes (K8s), or conversely, deploy everything using loose Docker Compose files on separate VMs/LXCs. Here, I chose a middle-ground approach: combining the orchestration power of **Kubernetes (K3s)** for *stateless* applications and the *native* performance of **Standalone LXC Containers** for *stateful* services (like databases and storage), all running on a single physical **Proxmox VE** hypervisor.
+
+---
+
+## 🛠️ Why Choose Proxmox VE?
+
+At the lowest level (*bare metal*), I installed **Proxmox VE**. Why not just install a standard Linux OS (like Ubuntu/Debian) and run Docker directly?
+
+1. **Type-1 Virtualization (Native Performance)**: Proxmox runs directly on the bare metal without desktop OS overhead.
+2. **VM vs. LXC Flexibility**: I can spin up Virtual Machines (VMs) for full OS environments requiring kernel isolation (like K8s nodes), and lightweight Linux Containers (LXCs) for simpler, RAM-friendly services (like databases).
+3. **Built-in Backups & Snapshots**: Before making risky experiments that could break the system, I can simply take a *Snapshot*. If things go wrong, I can *Rollback* in seconds.
+4. **Precise Resource Management**: I can monitor and restrict CPU, RAM, and disk I/O for each container to prevent them from choking each other out.
+
+---
+
+## ☸️ Why Kubernetes? Isn't it Overkill?
+
+Short answer: **Yes, for a personal homelab scale, Kubernetes is absolutely overkill.**
+
+Managing a K8s cluster requires extra RAM for the control plane, complex network configuration, and a steep learning curve. However, I had one absolute requirement that made K8s the most logical choice: **Dynamic Client Provisioning (Multi-Tenancy)**.
+
+I am building a SaaS/multi-tenant platform where every time a new client registers, the system must automatically:
+* Provision a new isolated application instance (isolated resources and network).
+* Set up a new database and user.
+* Configure subdomain routing and SSL/TLS automatically.
+
+If I used loose Docker Compose setups, my backend would have to manually SSH into the server, write dynamic compose files, and run shell commands. This is insecure and highly prone to race conditions.
+
+With Kubernetes, my backend simply targets the **Kube API** declaratively: *"Please create a new Namespace, create this Deployment, and attach this IngressRoute."* Kubernetes handles the rest (orchestration, node scheduling, auto-healing if a pod dies, etc.). K8s is not just a deployment tool; it is the **system engine** for my infrastructure automation.
+
+---
+
+## 🚀 Why K3s Instead of Standard K8s (Kubeadm)?
+
+Despite needing Kubernetes, I avoided the standard K8s distribution (like *kubeadm*). In a homelab environment where RAM is gold, **K3s (by Rancher)** is a lifesaver.
+
+1. **Extremely Lightweight**: K3s is packaged as a single small binary and consumes only about 512MB of RAM per node (compared to standard K8s which can consume gigabytes just for the control plane).
+2. **Resource-Efficient**: K3s strips out all cloud provider integrations (like AWS/GCP integrations) that are useless in a homelab, and replaces the heavy internal database etcd with SQLite (or external Postgres) which is far lighter.
+3. **100% Compatibility**: Despite being lightweight, K3s maintains full compatibility with the standard Kubernetes API. Any standard Kube YAML manifest can run here out of the box.
+4. **Built-in Traefik & Local Storage**: K3s includes Traefik as the default Ingress Controller and a Local Path Provisioner for storage, so we don't have to install them manually.
 
 ---
 
 ## 🗺️ Architectural Topology Map
 
-To make things clear, here is a visualization of how traffic flows from the public internet down to the application pods inside the cluster, and how external components are connected:
+Here is a visualization of how traffic flows from the public internet down to the application pods inside the cluster, and how external components are connected:
 
 ```text
                                              [ Internet ]
@@ -73,7 +112,7 @@ To make things clear, here is a visualization of how traffic flows from the publ
 
 ---
 
-## 🌐 Traffic Flow: From the Internet to the Application Pod
+## 🌐 Traffic Flow: From the Internet to the Application Pod (Public Access)
 
 How does a request from a user's browser reach our application inside the Kube cluster without having to configure port forwarding on our ISP router?
 

--- a/src/contents/posts/en/homelab-architecture-k8s-lxc-proxmox.mdx
+++ b/src/contents/posts/en/homelab-architecture-k8s-lxc-proxmox.mdx
@@ -1,0 +1,167 @@
+---
+title: "Modern Homelab Architecture Design: Integrating K8s & Standalone LXC on Proxmox VE"
+slug: {
+  en: "homelab-architecture-k8s-lxc-proxmox",
+  id: "arsitektur-homelab-k8s-lxc-proxmox"
+}
+date: 2026-06-28
+description: "How to combine the flexibility of Kubernetes (K3s) for stateless applications and the native performance of LXC for databases on a single Proxmox VE physical server securely and cleanly."
+keywords: "Homelab, Kubernetes, K3s, LXC, Proxmox, Cloudflare Tunnel, Traefik, IaC, Terraform, DevOps"
+tags: ["infrastructure", "homelab", "kubernetes", "proxmox", "devops"]
+image: "/media/default-banners/8.jpg"
+---
+
+Following my previous post on why building a homelab still matters, this time I want to dive deeper into the **latest homelab architecture design** I have implemented.
+
+Many people starting out with a homelab immediately deploy everything inside Kubernetes (K8s), or conversely, deploy everything using loose Docker Compose files on separate VMs/LXCs. Here, I chose a middle-ground approach: a **Hybrid Workload Architecture**—combining the orchestration power of **Kubernetes (K3s)** for *stateless* applications and the *native* performance of **Standalone LXC Containers** for *stateful* services (like databases and storage), all running on a single physical **Proxmox VE** hypervisor.
+
+---
+
+## 🗺️ Architectural Topology Map
+
+To make things clear, here is a visualization of how traffic flows from the public internet down to the application pods inside the cluster, and how external components are connected:
+
+```text
+                                             [ Internet ]
+                                                  │
+                                                  ▼
+                                         [ Cloudflare Edge ]
+                                                  │ (Wildcard *.mycloud.dev)
+                                                  ▼
+    ====================================== PROXMOX VE HOST ===========================================
+    │                                                                                                │
+    │  ┌───────────────────────── KUBERNETES (K3s) CLUSTER (192.168.1.x) ────────────────────────┐  │
+    │  │                                                                                        │  │
+    │  │  [ kube-master (101) ] ── (Control Plane / API Server)                                 │  │
+    │  │                                                                                        │  │
+    │  │  [ kube-worker-1 (107) ]                        [ kube-worker-2 (108) ]                │  │
+    │  │  ┌───────────────────────────────┐              ┌───────────────────────────────┐      │  │
+    │  │  │  cloudflared (Tunnel Pod)     │              │  client-worker Pod            │      │  │
+    │  │  │        │                      │              │                               │      │  │
+    │  │  │        ▼                      │              │                               │      │  │
+    │  │  │  Traefik (Ingress Pod) ◄──────┼──────────────┼──────────────┐                │      │  │
+    │  │  │        │                      │              │              │                │      │  │
+    │  │  │        ├─► app-service Pod    │              │              │                │      │  │
+    │  │  │        ├─► core-backend Pod   │              │              │                │      │  │
+    │  │  │        │                      │              │              │                │      │  │
+    │  │  │        ├─► [Namespace: client]│              │              │                │      │  │
+    │  │  │        │    ├── client-a Pod  │              │              │                │      │  │
+    │  │  │        │    └── client-b Pod  │              │              │                │      │  │
+    │  │  │        │                      │              │              │                │      │  │
+    │  │  │        └─► [Namespace: monitor]              │              │                │      │  │
+    │  │  │             ├── Grafana Pod   │              │              │                │      │  │
+    │  │  │             └── Prometheus Pod│              │              │                │      │  │
+    │  │  └───────────────────────────────┘              └──────────────┼────────────────┘      │  │
+    │  │                                                                │                       │  │
+    │  └───────────────────┬────────────────────────────────────────────┼───────────────────────┘  │
+    │                      ▲                                            │ (Local Routing)          │
+    │                      │ (Bind Mounts: /mnt/shared_nas)             │                          │
+    │  ┌───────────────────────────────── STANDALONE LXCs ──────────────────────────────────────┐  │
+    │  │                                                                │                       │  │
+    │  │  [ 100: staging-host ] ◄── (Builds / Staging / Docker) ────────┘                       │  │
+    │  │  [ 102: agent-host ]   ◄── (AI Agent Workspace)                                         │  │
+    │  │  [ 103: db-cluster ]   ◄── (Central PostgreSQL DB) ◄── [ K8s Pods / Apps ]              │  │
+    │  │  [ 104: virtual-nas ]  ◄── (Shared NAS Storage)                                        │  │
+    │  │  [ 105: vpn-gateway ]  ◄── (Private VPN Entrypoint) ──► [ Local Traffic to Traefik ]   │  │
+    │  │                                                                                        │  │
+    │  └────────────────────────────────────────────────────────────────────────────────────────┘  │
+    │                                                                                                │
+    ==================================================================================================
+```
+
+*Note: All IP addresses and domain names above have been sanitized using dummy Class C IPs (`192.168.1.x`) and a dummy domain name (`mycloud.dev`) to ensure system security.*
+
+---
+
+## 🌐 Traffic Flow: From the Internet to the Application Pod
+
+How does a request from a user's browser reach our application inside the Kube cluster without having to configure port forwarding on our ISP router?
+
+Here is the path:
+
+1. **Cloudflare Edge (DNS & SSL)**
+   The user accesses `app.mycloud.dev`. This request is first received by the nearest Cloudflare Edge server. Cloudflare handles SSL/TLS termination automatically at their edge.
+2. **Cloudflare Tunnel (`cloudflared`)**
+   Inside the Kubernetes cluster, we run a **Cloudflare Tunnel (`cloudflared`)** deployment as a Pod. This pod establishes secure outbound connections (tunnels) to Cloudflare Edge. Because the connection is outbound, we do not need to open any inbound ports on our local firewall.
+3. **Traefik Ingress Controller**
+   Once the request passes through the tunnel, Cloudflare forwards it to our `cloudflared` Pod. This pod then throws the traffic to the internal Service of the **Traefik Ingress Controller** (acting as the main reverse proxy in the cluster).
+4. **Ingress Routing**
+   Traefik reads the registered `Ingress` or `IngressRoute` configurations. It matches the routing rule: *"If the host is `app.mycloud.dev`, route the traffic to Service `core-backend-service` on port `9000`"*.
+5. **Kube Service & Pod**
+   The traffic finally reaches the target application Pod securely and with minimal latency.
+
+---
+
+## 🔀 Out-of-Cluster Communication: Accessing Standalone LXCs
+
+One of the challenges of this architecture is **how pods inside Kubernetes can access databases or staging services residing outside the K8s cluster (on standalone LXCs)?**
+
+Kubernetes provides a clean native feature to handle this without having to hardcode physical IP addresses inside our application code:
+
+### 1. K8s Service Without Selector
+Normally, K8s Services distribute traffic to Pods based on a label selector. However, we can create a Service **without a selector**:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: db-cluster-svc
+  namespace: default
+spec:
+  ports:
+    - protocol: TCP
+      port: 5432
+      targetPort: 5432
+```
+
+### 2. K8s Endpoints Manual Definition
+Because the Service above has no selector, Kube will not create endpoints automatically. We must define the endpoint manually to point to the physical IP of the standalone LXC (e.g., `db-cluster` at IP `192.168.1.103`):
+
+```yaml
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: db-cluster-svc
+  namespace: default
+subsets:
+  - addresses:
+      - ip: 192.168.1.103
+    ports:
+      - port: 5432
+```
+
+Using this method, our applications inside the Kube cluster can simply connect to the internal host `db-cluster-svc.default.svc.cluster.local:5432`. If the physical database IP changes in the future, we only need to update this `Endpoints` configuration file without modifying any application code.
+
+---
+
+## ⚙️ Dynamic Provisioning: Automating Client Pods
+
+For SaaS requirements or multi-tenant applications, we need to spin up new application instances dynamically when a new client registers. With this architecture, the flow is highly elegant:
+
+1. **Subscription Request**
+   A user registers, and our backend (`core-backend`) processes the request.
+2. **Database Provisioning**
+   The backend contacts the `db-cluster` programmatically to create an isolated database and database user for the client:
+   * **Database Name**: `pod_db_<product_name>_<workspace_id>` (e.g., `pod_db_service_clientx`)
+   * **Database User**: `pod_user_<product_name>_<workspace_id>` (e.g., `pod_user_service_clientx`)
+3. **K8s API Call**
+   The backend connects to the Kubernetes API Server via the internal domain **`k8s-api.mycloud.dev`** to provision new resources:
+   * Creates an isolated **Namespace**: `client-pod-<product_name>-<workspace_id>` (e.g., `client-pod-service-clientx`).
+   * Creates a **Secret** containing the client's unique database credentials.
+   * Creates the **Deployment**, **Service**, and **IngressRoute (Traefik)** to route the client's subdomain (`clientx.mycloud.dev`).
+
+### Why Isolate Per Namespace?
+By isolating each client instance in its own namespace:
+* **Strict Security Isolation**: Client A cannot inspect or access resources belonging to Client B internally.
+* **Resource Quota**: We can restrict CPU/RAM usage per client strictly using Kube `ResourceQuota`.
+* **Clean Deprovisioning**: If a client unsubscribes, the backend simply deletes the namespace. Kubernetes garbage collector automatically cleans up all resources inside it without leaving stray files on the host.
+
+---
+
+## 💡 Conclusion
+
+Separating responsibilities between **Kubernetes** (for dynamic and stateless applications) and **Standalone LXC** (for databases and storage) provides incredible stability to the homelab.
+
+We get all the benefits of modern orchestration from Kubernetes (such as auto-healing, easy scaling, and dynamic provisioning via API), without sacrificing the read-write disk performance of databases, which are typically slower if run inside Kubernetes virtual storage.
+
+The entire infrastructure is defined using **Terraform** for the Proxmox side, ensuring that if a server dies, we can re-provision our entire homelab in minutes!

--- a/src/contents/posts/id/arsitektur-homelab-k8s-lxc-proxmox.mdx
+++ b/src/contents/posts/id/arsitektur-homelab-k8s-lxc-proxmox.mdx
@@ -1,25 +1,64 @@
 ---
-title: "Desain Arsitektur Homelab Modern: Integrasi K8s & Standalone LXC di Proxmox VE"
+title: "Bagaimana Saya Membangun Arsitektur Homelab: Dari Bare Metal hingga Terhubung ke Internet"
 slug: {
   en: "homelab-architecture-k8s-lxc-proxmox",
   id: "arsitektur-homelab-k8s-lxc-proxmox"
 }
 date: 2026-06-28
-description: "Bagaimana cara menggabungkan fleksibilitas Kubernetes (K3s) untuk aplikasi stateless dan performa native LXC untuk database di satu server fisik Proxmox secara aman dan rapi."
-keywords: "Homelab, Kubernetes, K3s, LXC, Proxmox, Cloudflare Tunnel, Traefik, IaC, Terraform, DevOps"
+description: "Panduan membangun arsitektur homelab mandiri dari server fisik bare metal, virtualisasi Proxmox, orkestrasi Kubernetes (K3s), hingga diekspos ke internet publik secara aman."
+keywords: "Homelab, Kubernetes, K3s, LXC, Proxmox, Cloudflare Tunnel, Traefik, IaC, Terraform, DevOps, Bare Metal"
 tags: ["infrastructure", "homelab", "kubernetes", "proxmox", "devops"]
 image: "/media/default-banners/8.jpg"
 ---
 
-Setelah beberapa waktu lalu gue sempat bahas kenapa homelab itu penting, kali ini gue mau bedah lebih dalam soal **desain arsitektur homelab terbaru** yang gue terapkan. 
+Setelah beberapa waktu lalu gue sempat bahas kenapa homelab itu penting, kali ini gue mau bedah lebih dalam soal **bagaimana gue membangun arsitektur homelab terbaru** dari level fisik (*bare metal*) sampai bisa diakses secara aman dari internet publik.
 
-Banyak orang yang ketika mulai homelab langsung hajar semua dideploy di dalam Kubernetes (K8s), atau sebaliknya, semuanya pakai Docker Compose lepasan di VM/LXC terpisah. Di sini, gue memilih pendekatan jalan tengah alias **Hybrid Workload Architecture**: menggabungkan kekuatan orkestrasi **Kubernetes (K3s)** untuk aplikasi *stateless* dan performa *native* **Standalone LXC** untuk layanan *stateful* (seperti database dan storage), semuanya berjalan di atas satu hypervisor fisik **Proxmox VE**.
+Banyak orang yang ketika mulai homelab langsung hajar semua dideploy di dalam Kubernetes (K8s), atau sebaliknya, semuanya pakai Docker Compose lepasan di VM/LXC terpisah. Di sini, gue memilih pendekatan jalan tengah: menggabungkan kekuatan orkestrasi **Kubernetes (K3s)** untuk aplikasi *stateless* dan performa *native* **Standalone LXC** untuk layanan *stateful* (seperti database dan storage), semuanya berjalan di atas satu hypervisor fisik **Proxmox VE**.
+
+---
+
+## 🛠️ Kenapa Memilih Proxmox VE?
+
+Sebagai fondasi paling bawah (*bare metal*), gue menginstall **Proxmox VE**. Kenapa gak langsung install OS Linux biasa (seperti Ubuntu/Debian) lalu pasang Docker?
+
+1. **Virtualisasi Type-1 (Native Performance)**: Proxmox berjalan langsung di atas hardware tanpa overhead OS desktop.
+2. **Fleksibilitas VM vs LXC**: Gue bisa membuat Virtual Machine (VM) untuk OS penuh yang butuh isolasi kernel (seperti node K8s), sekaligus membuat Linux Containers (LXC) yang super ringan dan hemat RAM untuk service sederhana (seperti database).
+3. **Backup & Snapshot Terintegrasi**: Sebelum melakukan eksperimen aneh-aneh yang berpotensi merusak sistem, tinggal pencet tombol *Snapshot*. Jika error, tinggal *Rollback* dalam hitungan detik.
+4. **Manajemen Resource yang Presisi**: Gue bisa memantau dan membatasi CPU, RAM, dan I/O disk untuk masing-masing container agar tidak saling memakan resource satu sama lain.
+
+---
+
+## ☸️ Kenapa Pakai Kubernetes? Bukannya Overkill?
+
+Jawabannya singkat: **Ya, untuk skala homelab pribadi, Kubernetes itu sangat overkill.** 
+
+Mengelola cluster K8s butuh resource RAM tambahan untuk control plane, konfigurasi networking yang rumit, dan kurva belajar yang cukup curam. Tapi, gue punya satu kebutuhan mutlak yang membuat K8s menjadi pilihan paling logis: **Dynamic Client Provisioning (Multi-Tenancy)**.
+
+Gue sedang membangun platform SaaS/multi-tenant di mana setiap kali ada client baru mendaftar, sistem harus secara otomatis:
+* Membuat instance aplikasi baru yang terisolasi secara resource dan network.
+* Menyiapkan database baru beserta user-nya.
+* Mengatur routing subdomain (SSL/TLS) secara otomatis.
+
+Jika menggunakan Docker Compose lepasan, backend gue harus melakukan SSH manual ke server, menulis file compose dinamis, lalu menjalankan perintah shell. Ini sangat tidak aman dan rawan error (*race condition*). 
+
+Dengan Kubernetes, backend gue cukup menembak **Kube API** secara deklaratif: *"Tolong buatkan Namespace baru, buat Deployment ini, dan pasang IngressRoute ini."* Kubernetes yang akan menangani sisanya (orkestrasi, scheduling node, auto-healing jika pod mati, dll). K8s bukan sekadar alat *deploy*, tapi adalah **system engine** untuk otomatisasi infrastruktur gue.
+
+---
+
+## 🚀 Kenapa K3s, Bukan K8s Standar (Kubeadm)?
+
+Meskipun butuh Kubernetes, gue tidak menggunakan distribusi K8s standar (seperti *kubeadm*). Di lingkungan homelab di mana resource RAM sangat berharga, **K3s (oleh Rancher)** adalah penyelamat.
+
+1. **Sangat Ringan**: K3s dikemas dalam satu file binary berukuran kecil dan hanya memakan RAM sekitar 512MB per node (dibandingkan K8s standar yang bisa memakan RAM bergiga-giga hanya untuk control plane).
+2. **Resource-Efficient**: K3s membuang semua provider cloud bawaan (seperti AWS/GCP integrations) yang gak berguna di homelab kita, serta mengganti database internal etcd dengan SQLite (atau Postgres eksternal) yang jauh lebih ringan.
+3. **Kompatibilitas 100%**: Meskipun ringan, K3s tetap mempertahankan kompatibilitas penuh dengan API Kubernetes standar. Semua manifest YAML Kube biasa bisa langsung jalan di sini.
+4. **Bawaan Traefik & Local Storage**: K3s langsung menyertakan Traefik sebagai Ingress Controller bawaan dan Local Path Provisioner untuk storage, jadi kita gak perlu install manual dari nol.
 
 ---
 
 ## 🗺️ Peta Topologi Arsitektur
 
-Biar gak abstrak, berikut adalah gambaran bagaimana traffic mengalir dari internet luar sampai ke pod aplikasi di dalam cluster, serta bagaimana komponen di luar cluster saling terhubung:
+Berikut adalah gambaran bagaimana traffic mengalir dari internet luar sampai ke pod aplikasi di dalam cluster, serta bagaimana komponen di luar cluster saling terhubung:
 
 ```text
                                              [ Internet ]
@@ -42,7 +81,6 @@ Biar gak abstrak, berikut adalah gambaran bagaimana traffic mengalir dari intern
     │  │  │  Traefik (Ingress Pod) ◄──────┼──────────────┼──────────────┐                │      │  │
     │  │  │        │                      │              │              │                │      │  │
     │  │  │        ├─► app-service Pod    │              │              │                │      │  │
-    │  │  │        │                      │              │              │                │      │  │
     │  │  │        ├─► core-backend Pod   │              │              │                │      │  │
     │  │  │        │                      │              │              │                │      │  │
     │  │  │        ├─► [Namespace: client]│              │              │                │      │  │
@@ -74,7 +112,7 @@ Biar gak abstrak, berikut adalah gambaran bagaimana traffic mengalir dari intern
 
 ---
 
-## 🌐 Alur Trafik: Dari Internet ke Pod Aplikasi
+## 🌐 Alur Trafik: Dari Internet ke Pod Aplikasi (Public Access)
 
 Bagaimana sebuah request dari browser user di internet luar bisa sampai ke aplikasi kita di dalam cluster Kube tanpa kita harus membuka port (port forwarding) di router ISP?
 

--- a/src/contents/posts/id/arsitektur-homelab-k8s-lxc-proxmox.mdx
+++ b/src/contents/posts/id/arsitektur-homelab-k8s-lxc-proxmox.mdx
@@ -1,0 +1,168 @@
+---
+title: "Desain Arsitektur Homelab Modern: Integrasi K8s & Standalone LXC di Proxmox VE"
+slug: {
+  en: "homelab-architecture-k8s-lxc-proxmox",
+  id: "arsitektur-homelab-k8s-lxc-proxmox"
+}
+date: 2026-06-28
+description: "Bagaimana cara menggabungkan fleksibilitas Kubernetes (K3s) untuk aplikasi stateless dan performa native LXC untuk database di satu server fisik Proxmox secara aman dan rapi."
+keywords: "Homelab, Kubernetes, K3s, LXC, Proxmox, Cloudflare Tunnel, Traefik, IaC, Terraform, DevOps"
+tags: ["infrastructure", "homelab", "kubernetes", "proxmox", "devops"]
+image: "/media/default-banners/8.jpg"
+---
+
+Setelah beberapa waktu lalu gue sempat bahas kenapa homelab itu penting, kali ini gue mau bedah lebih dalam soal **desain arsitektur homelab terbaru** yang gue terapkan. 
+
+Banyak orang yang ketika mulai homelab langsung hajar semua dideploy di dalam Kubernetes (K8s), atau sebaliknya, semuanya pakai Docker Compose lepasan di VM/LXC terpisah. Di sini, gue memilih pendekatan jalan tengah alias **Hybrid Workload Architecture**: menggabungkan kekuatan orkestrasi **Kubernetes (K3s)** untuk aplikasi *stateless* dan performa *native* **Standalone LXC** untuk layanan *stateful* (seperti database dan storage), semuanya berjalan di atas satu hypervisor fisik **Proxmox VE**.
+
+---
+
+## 🗺️ Peta Topologi Arsitektur
+
+Biar gak abstrak, berikut adalah gambaran bagaimana traffic mengalir dari internet luar sampai ke pod aplikasi di dalam cluster, serta bagaimana komponen di luar cluster saling terhubung:
+
+```text
+                                             [ Internet ]
+                                                  │
+                                                  ▼
+                                         [ Cloudflare Edge ]
+                                                  │ (Wildcard *.mycloud.dev)
+                                                  ▼
+    ====================================== PROXMOX VE HOST ===========================================
+    │                                                                                                │
+    │  ┌───────────────────────── KUBERNETES (K3s) CLUSTER (192.168.1.x) ────────────────────────┐  │
+    │  │                                                                                        │  │
+    │  │  [ kube-master (101) ] ── (Control Plane / API Server)                                 │  │
+    │  │                                                                                        │  │
+    │  │  [ kube-worker-1 (107) ]                        [ kube-worker-2 (108) ]                │  │
+    │  │  ┌───────────────────────────────┐              ┌───────────────────────────────┐      │  │
+    │  │  │  cloudflared (Tunnel Pod)     │              │  client-worker Pod            │      │  │
+    │  │  │        │                      │              │                               │      │  │
+    │  │  │        ▼                      │              │                               │      │  │
+    │  │  │  Traefik (Ingress Pod) ◄──────┼──────────────┼──────────────┐                │      │  │
+    │  │  │        │                      │              │              │                │      │  │
+    │  │  │        ├─► app-service Pod    │              │              │                │      │  │
+    │  │  │        │                      │              │              │                │      │  │
+    │  │  │        ├─► core-backend Pod   │              │              │                │      │  │
+    │  │  │        │                      │              │              │                │      │  │
+    │  │  │        ├─► [Namespace: client]│              │              │                │      │  │
+    │  │  │        │    ├── client-a Pod  │              │              │                │      │  │
+    │  │  │        │    └── client-b Pod  │              │              │                │      │  │
+    │  │  │        │                      │              │              │                │      │  │
+    │  │  │        └─► [Namespace: monitor]              │              │                │      │  │
+    │  │  │             ├── Grafana Pod   │              │              │                │      │  │
+    │  │  │             └── Prometheus Pod│              │              │                │      │  │
+    │  │  └───────────────────────────────┘              └──────────────┼────────────────┘      │  │
+    │  │                                                                │                       │  │
+    │  └───────────────────┬────────────────────────────────────────────┼───────────────────────┘  │
+    │                      ▲                                            │ (Local Routing)          │
+    │                      │ (Bind Mounts: /mnt/shared_nas)             │                          │
+    │  ┌───────────────────────────────── STANDALONE LXCs ──────────────────────────────────────┐  │
+    │  │                                                                │                       │  │
+    │  │  [ 100: staging-host ] ◄── (Builds / Staging / Docker) ────────┘                       │  │
+    │  │  [ 102: agent-host ]   ◄── (AI Agent Workspace)                                         │  │
+    │  │  [ 103: db-cluster ]   ◄── (Central PostgreSQL DB) ◄── [ K8s Pods / Apps ]              │  │
+    │  │  [ 104: virtual-nas ]  ◄── (Shared NAS Storage)                                        │  │
+    │  │  [ 105: vpn-gateway ]  ◄── (Private VPN Entrypoint) ──► [ Local Traffic to Traefik ]   │  │
+    │  │                                                                                        │  │
+    │  └────────────────────────────────────────────────────────────────────────────────────────┘  │
+    │                                                                                                │
+    ==================================================================================================
+```
+
+*Catatan: Semua IP dan domain di atas sudah disanitasi menggunakan IP dummy kelas C (`192.168.1.x`) dan domain dummy (`mycloud.dev`) untuk menjaga keamanan sistem.*
+
+---
+
+## 🌐 Alur Trafik: Dari Internet ke Pod Aplikasi
+
+Bagaimana sebuah request dari browser user di internet luar bisa sampai ke aplikasi kita di dalam cluster Kube tanpa kita harus membuka port (port forwarding) di router ISP?
+
+Berikut adalah jalurnya:
+
+1. **Cloudflare Edge (DNS & SSL)**
+   User mengakses `app.mycloud.dev`. Request ini pertama kali diterima oleh server Cloudflare terdekat. Cloudflare menangani SSL/TLS handshake secara otomatis di edge mereka.
+2. **Cloudflare Tunnel (`cloudflared`)**
+   Di dalam cluster Kubernetes, kita menjalankan deployment **Cloudflare Tunnel (`cloudflared`)** sebagai Pod. Pod ini membuat koneksi outbound aman (tunnel) ke Cloudflare Edge. Karena koneksinya outbound, kita gak perlu buka port masuk di firewall lokal.
+3. **Traefik Ingress Controller**
+   Begitu request melewati tunnel, Cloudflare meneruskannya ke Pod `cloudflared` kita. Pod ini kemudian melempar trafik tersebut ke internal Service milik **Traefik Ingress Controller** (yang bertindak sebagai reverse proxy utama di dalam cluster).
+4. **Ingress Routing**
+   Traefik membaca konfigurasi `Ingress` atau `IngressRoute` yang terdaftar. Dia mencocokkan rule: *"Jika host adalah `app.mycloud.dev`, arahkan trafik ke Service `core-backend-service` di port `9000`"*.
+5. **Kube Service & Pod**
+   Trafik akhirnya sampai ke Pod aplikasi target secara aman dan dengan latensi minimal.
+
+---
+
+## 🔀 Komunikasi Keluar Cluster: Mengakses Standalone LXC
+
+Salah satu tantangan arsitektur ini adalah **bagaimana pod di dalam Kubernetes bisa mengakses database atau service staging yang berada di luar cluster K8s (pada LXC standalone)?**
+
+Di Kubernetes, ada fitur bawaan yang sangat bersih untuk mengatasi ini tanpa perlu melakukan hardcode IP fisik di dalam kode aplikasi kita:
+
+### 1. K8s Service Tanpa Selector
+Biasanya, Service di K8s mendistribusikan trafik ke Pod berdasarkan label selector. Tapi, kita bisa membuat Service **tanpa selector**:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: db-cluster-svc
+  namespace: default
+spec:
+  ports:
+    - protocol: TCP
+      port: 5432
+      targetPort: 5432
+```
+
+### 2. K8s Endpoints Manual
+Karena Service di atas tidak memiliki selector, Kube tidak akan membuat endpoint secara otomatis. Kita harus mendefinisikan endpoint-nya secara manual untuk mengarah ke IP fisik LXC standalone (misalnya `db-cluster` di IP `192.168.1.103`):
+
+```yaml
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: db-cluster-svc
+  namespace: default
+subsets:
+  - addresses:
+      - ip: 192.168.1.103
+    ports:
+      - port: 5432
+```
+
+Dengan cara ini, aplikasi kita di dalam cluster Kube cukup menembak host internal `db-cluster-svc.default.svc.cluster.local:5432`. Jika suatu hari IP database fisik kita berubah, kita hanya perlu mengupdate file konfigurasi `Endpoints` ini saja tanpa perlu menyentuh kode aplikasi.
+
+---
+
+## ⚙️ Dynamic Provisioning: Otomatisasi Client Pod
+
+Untuk kebutuhan SaaS atau aplikasi multi-tenant, kita perlu membuat instance aplikasi baru secara dinamis ketika ada client baru yang mendaftar. Dengan arsitektur ini, alurnya menjadi sangat elegan:
+
+1. **Request Langganan**
+   User mendaftar dan backend kita (`core-backend`) menerima request tersebut.
+2. **Database Provisioning**
+   Backend menghubungi `db-cluster` secara terprogram untuk membuat database dan user terisolasi khusus untuk client tersebut:
+   * **Database Name**: `pod_db_<product_name>_<workspace_id>` (e.g., `pod_db_service_clientx`)
+   * **Database User**: `pod_user_<product_name>_<workspace_id>` (e.g., `pod_user_service_clientx`)
+3. **K8s API Call**
+   Backend menghubungi Kubernetes API Server via internal domain **`k8s-api.mycloud.dev`** untuk membuat resource baru:
+   * Membuat **Namespace** terisolasi: `client-pod-<product_name>-<workspace_id>` (e.g., `client-pod-service-clientx`).
+   * Membuat **Secret** berisi kredensial database unik milik client tersebut.
+   * Membuat **Deployment**, **Service**, dan **IngressRoute (Traefik)** khusus untuk meroute subdomain client (`clientx.mycloud.dev`).
+
+### Kenapa Dipisah Per Namespace?
+Dengan memisahkan setiap instance client ke namespace-nya masing-masing:
+* **Isolasi Keamanan Ketat**: Client A tidak akan bisa mengintip atau mengakses resource milik Client B secara internal.
+* **Resource Quota**: Kita bisa membatasi penggunaan CPU/RAM per client secara tegas menggunakan Kube `ResourceQuota`.
+* **Deprovisioning yang Bersih**: Jika client berhenti berlangganan, backend cukup menghapus namespace tersebut. Kubernetes akan otomatis membersihkan seluruh resource di dalamnya tanpa ada sisa file sampah di server.
+
+---
+
+## 💡 Kesimpulan
+
+Memisahkan tanggung jawab antara **Kubernetes** (untuk aplikasi dinamis dan stateless) dan **LXC Standalone** (untuk database dan storage) terbukti memberikan kestabilan yang luar biasa pada homelab. 
+
+Kita mendapatkan semua keuntungan orkestrasi modern dari Kubernetes (seperti auto-healing, easy scaling, dan dynamic provisioning via API), tanpa mengorbankan performa read-write database disk yang biasanya lambat jika dijalankan di dalam storage virtual Kubernetes.
+
+Semua infrastruktur ini didefinisikan menggunakan **Terraform** untuk sisi Proxmox-nya, sehingga jika server mati, kita bisa melakukan *re-provisioning* seluruh homelab ini dalam hitungan menit!


### PR DESCRIPTION
Adds a new blog post in both Indonesian and English detailing our homelab architecture design:
- Explains the hybrid workload setup (K8s for stateless, standalone LXC for databases/stateful).
- Visualizes the topology map.
- Details the traffic flow from the internet (Cloudflare Edge -> Tunnel -> Traefik -> Pod).
- Details out-of-cluster communication using K8s Services without selectors and manual Endpoints.
- Explains dynamic client provisioning.
- Sanitizes all IPs to 192.168.1.x and domains to mycloud.dev, k8s-api, etc.
- Uses generic terms for products (e.g. client-pod, app-service).