### PR TITLE
fix(blog): address homelab post revisions and inline code wrapping

### DIFF
--- a/src/contents/posts/en/homelab-architecture-k8s-lxc-proxmox.mdx
+++ b/src/contents/posts/en/homelab-architecture-k8s-lxc-proxmox.mdx
@@ -32,7 +32,7 @@ At the lowest level (*bare metal*), I installed **Proxmox VE**. Why not just ins
 
 Short answer: **Yes, for a personal homelab scale, Kubernetes is absolutely overkill.**
 
-Managing a K8s cluster requires extra RAM for the control plane, complex network configuration, and a steep learning curve. However, I had one absolute requirement that made K8s the most logical choice: **Dynamic Client Provisioning (Multi-Tenancy)**.
+Managing a K8s cluster requires extra RAM for the control plane, complex network configuration, and a steep learning curve. In this setup, I am not chasing High Availability (HA) or advanced failover capabilities at all. My sole absolute requirement is **Dynamic Client Provisioning (Multi-Tenancy)**.
 
 I am building a SaaS/multi-tenant platform where every time a new client registers, the system must automatically:
 * Provision a new isolated application instance (isolated resources and network).
@@ -107,8 +107,6 @@ Here is a visualization of how traffic flows from the public internet down to th
     │                                                                                                │
     ==================================================================================================
 ```
-
-*Note: All IP addresses and domain names above have been sanitized using dummy Class C IPs (`192.168.1.x`) and a dummy domain name (`mycloud.dev`) to ensure system security.*
 
 ---
 

--- a/src/contents/posts/id/arsitektur-homelab-k8s-lxc-proxmox.mdx
+++ b/src/contents/posts/id/arsitektur-homelab-k8s-lxc-proxmox.mdx
@@ -32,7 +32,7 @@ Sebagai fondasi paling bawah (*bare metal*), gue menginstall **Proxmox VE**. Ken
 
 Jawabannya singkat: **Ya, untuk skala homelab pribadi, Kubernetes itu sangat overkill.** 
 
-Mengelola cluster K8s butuh resource RAM tambahan untuk control plane, konfigurasi networking yang rumit, dan kurva belajar yang cukup curam. Tapi, gue punya satu kebutuhan mutlak yang membuat K8s menjadi pilihan paling logis: **Dynamic Client Provisioning (Multi-Tenancy)**.
+Mengelola cluster K8s butuh resource RAM tambahan untuk control plane, konfigurasi networking yang rumit, dan kurva belajar yang cukup curam. Di sini, gue sama sekali gak ngejar fitur High Availability (HA) atau *failover* canggih lainnya untuk sekadar homelab. Kebutuhan mutlak gue murni satu hal: **Dynamic Client Provisioning (Multi-Tenancy)**.
 
 Gue sedang membangun platform SaaS/multi-tenant di mana setiap kali ada client baru mendaftar, sistem harus secara otomatis:
 * Membuat instance aplikasi baru yang terisolasi secara resource dan network.
@@ -107,8 +107,6 @@ Berikut adalah gambaran bagaimana traffic mengalir dari internet luar sampai ke 
     │                                                                                                │
     ==================================================================================================
 ```
-
-*Catatan: Semua IP dan domain di atas sudah disanitasi menggunakan IP dummy kelas C (`192.168.1.x`) dan domain dummy (`mycloud.dev`) untuk menjaga keamanan sistem.*
 
 ---
 

--- a/src/designs/styles/prism.css
+++ b/src/designs/styles/prism.css
@@ -59,6 +59,12 @@ pre::-webkit-scrollbar-thumb {
 
 code:not(.code-highlight) {
   @apply bg-base-300;
+  padding: 2px 6px;
+  border-radius: 0.3em;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
 }
 
 /* Selection */
@@ -249,9 +255,13 @@ pre[class*='language-'] {
 
 /* Inline code */
 :not(pre) > code[class*='language-'] {
-  padding: 4px 7px;
+  padding: 2px 6px;
   border-radius: 0.3em;
   white-space: normal;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
 }
 
 /* Code box limit */


### PR DESCRIPTION
Addresses revisions on the homelab post and fixes inline code UI issues:
- Removes the explicit sanitization note since it's unnecessary.
- Adds clarification that we are not chasing High Availability (HA) or failover, but purely dynamic provisioning.
- Fixes inline code block wrapping and overlapping issues by adding `word-break: break-word`, `overflow-wrap: break-word`, and `box-decoration-break: clone` to `prism.css`.