### PR TITLE
fix(blog): obfuscate backup filename and remove exact LXC size details

### DIFF
--- a/src/contents/posts/en/proxmox-nas-backup-loopback.mdx
+++ b/src/contents/posts/en/proxmox-nas-backup-loopback.mdx
@@ -19,7 +19,7 @@ Out of nowhere, while casually checking the server status, my eyes caught the NA
 
 Wait, what? It usually sits comfortably below 50GB. Why did it suddenly balloon like a developer's wallet on payday? And to make things worse, my Proxmox host had gone through a mysterious *crash/reboot loop* around 3:00 AM.
 
-After a quick investigation via SSH, I found the culprit. A massive dangling temp file was sitting in the backup storage: `vzdump-lxc-104-2026_06_28-03_09_23.tar.dat` weighing in at **74GB**! Right next to it were older massive backups of LXC 104 (`virtual-nas`) at 55GB and 15GB.
+After a quick investigation via SSH, I found the culprit. There was a massive dangling temp file sitting in the backup storage weighing in at **74GB**!
 
 That was the exact moment I realized I had just run face-first into my biggest infrastructure facepalm of the week.
 

--- a/src/contents/posts/id/loopback-backup-proxmox-nas.mdx
+++ b/src/contents/posts/id/loopback-backup-proxmox-nas.mdx
@@ -19,7 +19,7 @@ Tiba-tiba pas lagi santai ngecek status server, mata gue tertuju ke storage back
 
 Lho, anjir? Biasanya anteng di bawah 50GB. Kok tiba-tiba bengkak kayak dompet abis gajian? Dan yang lebih parah, server Proxmox gue sempet ngalamin *crash/reboot loop* misterius pas subuh sekitar jam 3 pagi.
 
-Setelah investigasi kilat via SSH, gue nemu biang keroknya. Ada file sampah raksasa ngegantung di storage backup: `vzdump-lxc-104-2026_06_28-03_09_23.tar.dat` sebesar **74GB**! Dan di sampingnya ada file backup lama LXC 104 (`virtual-nas`) berukuran 55GB dan 15GB.
+Setelah investigasi kilat via SSH, gue nemu biang keroknya. Ada file sampah raksasa ngegantung di storage backup sebesar **74GB**!
 
 Di sinilah gue sadar kalau gue baru aja kejedut tiang listrik infrastruktur paling epic minggu ini.
 


### PR DESCRIPTION
Obfuscates the exact vzdump backup filename and removes references to the sizes of other backups in the Proxmox NAS backup post as requested by Gading.