### PR TITLE
fix(blog): remove redundant intro sentence from NAS backup post

### DIFF
--- a/src/contents/posts/en/proxmox-nas-backup-loopback.mdx
+++ b/src/contents/posts/en/proxmox-nas-backup-loopback.mdx
@@ -21,8 +21,6 @@ Wait, what? It usually sits comfortably below 50GB. Why did it suddenly balloon 
 
 After a quick investigation via SSH, I found the culprit. There was a massive dangling temp file sitting in the backup storage weighing in at **74GB**!
 
-That was the exact moment I realized I had just run face-first into my biggest infrastructure facepalm of the week.
-
 ---
 
 ### The Incident: An Infinite Backup Loop

--- a/src/contents/posts/id/loopback-backup-proxmox-nas.mdx
+++ b/src/contents/posts/id/loopback-backup-proxmox-nas.mdx
@@ -21,8 +21,6 @@ Lho, anjir? Biasanya anteng di bawah 50GB. Kok tiba-tiba bengkak kayak dompet ab
 
 Setelah investigasi kilat via SSH, gue nemu biang keroknya. Ada file sampah raksasa ngegantung di storage backup sebesar **74GB**!
 
-Di sinilah gue sadar kalau gue baru aja kejedut tiang listrik infrastruktur paling epic minggu ini.
-
 ---
 
 ### Kronologi Kejadian: The Infinite Backup Loop


### PR DESCRIPTION
Removes the redundant introductory sentence ('Di sinilah gue sadar...' / 'That was the exact moment...') from the Proxmox NAS backup post as requested by Gading.