### PR TITLE
fix(banner): replace bright pink fallback gradient with dark mesh gradient

### DIFF
--- a/src/packages/components/layouts/Header/Banner.tsx
+++ b/src/packages/components/layouts/Header/Banner.tsx
@@ -36,8 +36,7 @@ function Banner(props: PropsWithChildren<Props>) {
   return (
     <div
       className={cn([
-        'relative overflow-hidden',
-        isDefaultBanner ? 'dark-mesh-gradient' : 'bg-gradient-to-tr from-primary to-accent'
+        'relative overflow-hidden dark-mesh-gradient'
       ])}
     >
       {/* Subtle grid pattern overlay for default banners (tech aesthetic) */}


### PR DESCRIPTION
This PR replaces the bright pink-to-purple fallback gradient (`bg-gradient-to-tr from-primary to-accent`) in the Banner component with the new `dark-mesh-gradient`. This prevents a bright pink flash when specific blog post images are loading.