### PR TITLE
fix(author): update twitter handle and comment out instagram and facebook social links

### DIFF
--- a/src/configs/author.ts
+++ b/src/configs/author.ts
@@ -3,10 +3,10 @@ export const AUTHOR_FULLNAME = 'Sutan Gading Fadhillah Nasution';
 export const AUTHOR_EMAIL = 'contact@gading.dev';
 
 /** social media */
-export const AUTHOR_FACEBOOK = 'gadingnstn';
-export const AUTHOR_INSTAGRAM = 'gadingnst';
+// export const AUTHOR_FACEBOOK = 'gadingnstn';
+// export const AUTHOR_INSTAGRAM = 'gadingnst';
 export const AUTHOR_GITHUB = 'gadingnst';
 export const AUTHOR_LINKEDIN = 'gadingnst';
 export const AUTHOR_STEAM = 'gadingnst';
-export const AUTHOR_TWITTER = 'gadingnstn';
+export const AUTHOR_TWITTER = 'gading_coder';
 export const AUTHOR_THREADS = 'gadingnst';

--- a/src/packages/components/layouts/Footer/SocialLinks.tsx
+++ b/src/packages/components/layouts/Footer/SocialLinks.tsx
@@ -1,7 +1,7 @@
 import {
-  AUTHOR_FACEBOOK,
+  // AUTHOR_FACEBOOK,
   AUTHOR_GITHUB,
-  AUTHOR_INSTAGRAM,
+  // AUTHOR_INSTAGRAM,
   AUTHOR_LINKEDIN,
   AUTHOR_THREADS,
   AUTHOR_TWITTER
@@ -23,12 +23,12 @@ const socialLinks = [
     icon: IconGithub,
     className: 'bg-[#333] shadow-gray-600'
   },
-  {
+  /* {
     name: 'Instagram',
     href: `https://instagram.com/${AUTHOR_INSTAGRAM}`,
     icon: IconInstagram,
     className: 'bg-gradient-to-r from-[#f09433] via-[#e6683c] via-[#dc2743] via-[#cc2366] to-[#bc1888] shadow-pink-500'
-  },
+  }, */
   {
     name: 'LinkedIn',
     href: `https://linkedin.com/in/${AUTHOR_LINKEDIN}`,
@@ -47,12 +47,12 @@ const socialLinks = [
     icon: IconThreads,
     className: 'bg-[#000] shadow-gray-800'
   },
-  {
+  /* {
     name: 'Facebook',
     href: `https://facebook.com/${AUTHOR_FACEBOOK}`,
     icon: IconFacebook,
     className: 'bg-[#1877F2] shadow-blue-500'
-  }
+  } */
 ];
 
 function SocialLinks() {


### PR DESCRIPTION
This PR updates the Twitter handle to @gading_coder and comments out the Instagram and Facebook social links in the footer, leaving only GitHub, LinkedIn, Twitter, and Threads active.