### PR TITLE
style: make footer flat and replace solid hr line with gradient divider

### DIFF
--- a/src/designs/styles/custom-utilities.css
+++ b/src/designs/styles/custom-utilities.css
@@ -80,17 +80,9 @@
   }
 
   .footer-custom {
-    min-height: 200px;
-    &::before {
-      content: "";
-      transform: skew(0, -10.25deg);
-      @screen md {
-        transform: skew(0, -5.25deg);
-      }
-      @apply
-        absolute left-0 right-0 transition-colors duration-200
-        bg-base-200 top-[150px] h-[2000px];
-    }
-    @apply relative overflow-hidden mt-14;
+    @apply relative mt-14 border-t border-base-300 dark:border-white/5;
+    background-color: var(--glass-bg);
+    backdrop-filter: blur(var(--glass-blur)) saturate(150%);
+    -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(150%);
   }
 }

--- a/src/packages/components/layouts/Footer/Footer.tsx
+++ b/src/packages/components/layouts/Footer/Footer.tsx
@@ -15,7 +15,7 @@ function Footer() {
           </p>
           <SocialLinks />
         </div>
-        <hr className="relative z-10" />
+        <div className="h-[1px] w-full bg-gradient-to-r from-transparent via-base-content/15 to-transparent relative z-10" />
         <div className="relative z-10 my-12 text-sm text-center sm:text-left">
           <span className="inline-block">&copy;&nbsp;{currentYear}&nbsp;</span>
           <Link className="inline-block font-semibold" href={BASE_URL}>{SITE_NAME}</Link>


### PR DESCRIPTION
This PR flattens the footer by removing the old Argon-style slant background skew effect, replacing it with a clean flat layout that uses the theme's glass variables. It also replaces the solid horizontal rule line with a modern fading gradient divider.