### PR TITLE
feat(blog): add part 2 teaser to part 1

### DIFF
--- a/src/contents/posts/en/how-i-handle-agent-memory-for-personal-ai-assistant.mdx
+++ b/src/contents/posts/en/how-i-handle-agent-memory-for-personal-ai-assistant.mdx
@@ -114,6 +114,12 @@ But before running that install command, ask yourself:
 
 Going back to the basics and understanding the core mechanics of the problem you are trying to solve is far more valuable than stacking dependencies. Sometimes, the most robust solution is just a structured text file (Markdown), a bit of regex, and a simple, precise automation script. It saves tokens, saves RAM, and saves you from maintenance headaches down the road.
 
+### What's Next?
+
+This flat RAG + NAS scheme is a solid starting foundation. However, as the daily notes accumulate over hundreds of days, the next challenges are tackling *index bloating*, *vector dilution*, and handling *graph traversals* (linking threaded chats across days) without sacrificing performance.
+
+In the next post, **Building Agent Memory with Vendor Lock-in Resistance (Part 2)**, I will dissect the continuation of this architecture. We will discuss how to refactor Nouva's memory system using a *Hierarchical Summary* and a simple *Hybrid Scoring* approach to keep memory retrieval instant, tidy, and of course, 100% free from vendor lock-in.
+
 ---
 
 *How do you handle your AI assistant's memory? Let's discuss on [Threads](https://www.threads.net/@gadingnst).*

--- a/src/contents/posts/id/bagaimana-saya-handle-agent-memory-untuk-skala-personal-ai-assistant.mdx
+++ b/src/contents/posts/id/bagaimana-saya-handle-agent-memory-untuk-skala-personal-ai-assistant.mdx
@@ -114,6 +114,12 @@ Tapi sebelum install, coba tanya dulu ke diri sendiri:
 
 Kembali ke dasar (*back to basics*) dan memahami core concept dari masalah yang mau diselesaikan itu jauh lebih penting dibanding numpuk dependency baru. Kadang, solusi terbaik cuma butuh file teks terstruktur (Markdown), sedikit regex, dan script automasi sederhana yang presisi. Lebih hemat token, hemat RAM, dan ga bikin pusing pas maintenance jangka panjang.
 
+### What's Next?
+
+Skema flat RAG + NAS ini adalah fondasi awal yang solid. Namun, ketika jumlah catatan harian mulai menumpuk hingga ratusan hari, tantangan berikutnya adalah bagaimana kita mengatasi *index bloating*, *vector dilution*, dan melakukan *graph traversal* (menghubungkan chat yang bersambung antar hari) tanpa mengorbankan performa.
+
+Di tulisan selanjutnya, yaitu **Membangun Agent Memory dengan Vendor Lock-in Resistance (Part 2)**, gw bakal bedah kelanjutan dari arsitektur ini. Kita akan bahas bagaimana merombak sistem memori Nouva menggunakan pendekatan *Hierarchical Summary* dan rumus *Hybrid Scoring* sederhana agar pencarian memori tetap instan, rapi, dan tentu saja, tetap 100% bebas dari vendor lock-in.
+
 ---
 
 *Gimana cara lu ngelola memori asisten AI lu? Yuk diskusi di [Threads](https://www.threads.net/@gadingnst).*


### PR DESCRIPTION
Adds the plain text teaser mentioning Part 2 at the end of the first agent memory post, without hyperlinks or em-dashes.