### PR TITLE
feat(blog): feature agent memory part 2 post

### DIFF
--- a/src/contents/posts/featured.json
+++ b/src/contents/posts/featured.json
@@ -1,14 +1,14 @@
 {
   "en": [
+    "building-agent-memory-free-vendor",
     "homelab-architecture-k8s-lxc-proxmox",
     "configure-gmail-alias-spf-dmarc",
-    "understanding-docker-and-kubernetes-philosophy",
-    "the-graphrag-trap"
+    "understanding-docker-and-kubernetes-philosophy"
   ],
   "id": [
+    "membangun-agent-memory-bebas-vendor",
     "arsitektur-homelab-k8s-lxc-proxmox",
     "gmail-alias-domain-sendiri-spf-dmarc",
-    "memahami-filosofi-docker-dan-kubernetes",
-    "jebakan-graphrag-uninstall-neo4j"
+    "memahami-filosofi-docker-dan-kubernetes"
   ]
 }


### PR DESCRIPTION
Replaces the featured 'uninstall neo4j' post with the new 'agent memory part 2' post, placing it at the very beginning of the featured list.