### PR TITLE
fix(blog): clarify RAG memory source handling

### DIFF
--- a/src/contents/posts/en/building-agent-memory-free-vendor.mdx
+++ b/src/contents/posts/en/building-agent-memory-free-vendor.mdx
@@ -43,7 +43,7 @@ Let's break down the key updates one by one.
 
 ### 1. Fighting Bloat with Daily Summary & YAML Frontmatter
 
-Previously, we synced raw daily notes directly to RAG. Now, before archiving daily notes to the NAS, the `auto-sync.py` script calls an LLM to generate a new file: `memory/summaries/YYYY-MM-DD.summary.md`.
+Previously, we relied on raw daily notes as the sole memory source in RAG. Now, before those daily notes are archived to the NAS, the `auto-sync.py` script calls an LLM to generate a new file: `memory/summaries/YYYY-MM-DD.summary.md`.
 
 This summary file is super clean and features a structured YAML frontmatter:
 

--- a/src/contents/posts/id/membangun-agent-memory-bebas-vendor.mdx
+++ b/src/contents/posts/id/membangun-agent-memory-bebas-vendor.mdx
@@ -43,7 +43,7 @@ Mari kita bedah satu per satu perubahan pentingnya.
 
 ### 1. Menolak Bloat dengan Daily Summary & YAML Frontmatter
 
-Dulu, kita langsung nge-sync daily notes mentah ke RAG. Sekarang, sebelum daily notes diarsipkan ke NAS, script `auto-sync.py` bakal manggil LLM untuk men-generate file baru: `memory/summaries/YYYY-MM-DD.summary.md`.
+Dulu, kita mengandalkan daily notes mentah sebagai satu-satunya data memori di RAG. Sekarang, sebelum daily notes tersebut diarsipkan ke NAS, script `auto-sync.py` bakal manggil LLM untuk men-generate file baru: `memory/summaries/YYYY-MM-DD.summary.md`.
 
 File summary ini super bersih dan dilengkapi dengan YAML frontmatter terstruktur:
 


### PR DESCRIPTION
Clarifies that raw daily notes are not completely abandoned in RAG, but rather summaries are introduced as a structured addition.