### PR TITLE
feat: add related blog references and agent-memory tag

### DIFF
--- a/src/contents/posts/en/building-agent-memory-free-vendor.mdx
+++ b/src/contents/posts/en/building-agent-memory-free-vendor.mdx
@@ -7,7 +7,7 @@ slug: {
 date: 2026-07-06
 description: "The next step in my AI Agent's memory experiments: solving index bloat with Two-Tier Hierarchical Summary, hybrid scoring (semantic + importance + recency), and graph link validation."
 keywords: "AI Agent, Agent Memory, RAG, AnythingLLM, Hierarchical Memory, Hybrid Scoring, Obsidian, OpenClaw"
-tags: ["ai", "infrastructure", "rag", "nouverse"]
+tags: ["agent-memory", "ai", "infrastructure", "rag", "nouverse"]
 image: "/media/blog/membangun-agent-memory-bebas-vendor/banner.png"
 ---
 
@@ -157,3 +157,9 @@ The final piece of the puzzle is historical data already archived on the NAS. To
 So, do I finally need an expensive, complex external memory stack? The answer remains **no**. I can still "hack" my way through using local markdown files, a few Python scripts, and simple hybrid scoring math to fit my real needs without wasting LLM tokens or depending on third-party vendors.
 
 This refactoring proves that with a well-structured markdown folder, YAML headers, a bit of hybrid scoring math, and standard markdown tools like Obsidian, you can build a smart, lightning-fast, and 100% self-owned AI Agent memory system.
+
+### Related Blogs
+This memory architecture didn't happen overnight. It is the evolution of several experiments and failures before it:
+1. [Building GraphRAG for Autonomous Agents with Neo4J and Graphitti](/blog/building-graphrag-neo4j-graphitti) (The initial phase of trying GraphRAG)
+2. [The GraphRAG Trap: Why I Uninstalled Neo4j for My Personal Assistant](/blog/the-graphrag-trap) (The decision to uninstall due to overkill)
+3. [How I Build Agent Memory Free from Vendor Lock-in](/blog/how-i-handle-agent-memory-for-personal-ai-assistant) (Initial solution using flat RAG + NAS)

--- a/src/contents/posts/en/building-graphrag-neo4j-graphitti.mdx
+++ b/src/contents/posts/en/building-graphrag-neo4j-graphitti.mdx
@@ -7,7 +7,7 @@ slug: {
 date: 2026-02-24
 description: "How to build autonomous agents with long-term memory using GraphRAG, Neo4J, and Graphitti."
 keywords: "RAG, AI Agents, MCP, GraphRAG, Neo4j, Graphiti, Long-term Memory"
-tags: ["ai", "rag", "mcp", "graphrag"]
+tags: ["agent-memory", "ai", "rag", "mcp", "graphrag"]
 image: "/media/blog/building-graphrag-neo4j-graphitti/banner.png"
 ---
 

--- a/src/contents/posts/en/how-i-handle-agent-memory-for-personal-ai-assistant.mdx
+++ b/src/contents/posts/en/how-i-handle-agent-memory-for-personal-ai-assistant.mdx
@@ -7,7 +7,7 @@ slug: {
 date: 2026-07-05
 description: "How I restructured my AI Agent's (Nouva) memory system from a noisy, bloated Vector DB into a lean, Two-Tier Hybrid RAG + NAS Markdown setup that covers 95% of personal needs."
 keywords: "AI Agent, Agent Memory, RAG, AnythingLLM, NAS, Markdown, Personal AI Assistant, OpenClaw"
-tags: ["ai", "infrastructure", "rag", "nouverse"]
+tags: ["agent-memory", "ai", "infrastructure", "rag", "nouverse"]
 image: "/media/blog/how-i-handle-agent-memory-for-personal-ai-assistant/banner.png"
 ---
 
@@ -119,6 +119,11 @@ Going back to the basics and understanding the core mechanics of the problem you
 This flat RAG + NAS scheme is a solid starting foundation. However, as the daily notes accumulate over hundreds of days, the next challenges are tackling *index bloating*, *vector dilution*, and handling *graph traversals* (linking threaded chats across days) without sacrificing performance.
 
 In the next post, **Building Agent Memory with Vendor Lock-in Resistance (Part 2)**, I will dissect the continuation of this architecture. We will discuss how to refactor Nouva's memory system using a *Hierarchical Summary* and a simple *Hybrid Scoring* approach to keep memory retrieval instant, tidy, and of course, 100% free from vendor lock-in.
+
+### Related Blogs
+To get the full picture of how I arrived at the local memory architecture in this post, you can read my previous experimental journeys:
+1. [Building GraphRAG for Autonomous Agents with Neo4J and Graphitti](/blog/building-graphrag-neo4j-graphitti) (Initial phase of trying GraphRAG)
+2. [The GraphRAG Trap: Why I Uninstalled Neo4j for My Personal Assistant](/blog/the-graphrag-trap) (The phase where I realized it was overkill)
 
 ---
 

--- a/src/contents/posts/en/the-graphrag-trap.mdx
+++ b/src/contents/posts/en/the-graphrag-trap.mdx
@@ -7,7 +7,7 @@ slug: {
 date: 2026-02-28
 description: "Why GraphRAG is often overkill for personal AI assistants and why I decided to pivot back to a simpler RAG + Memory stack for Nouva."
 keywords: "GraphRAG, RAG, Neo4j, AI Agent, Personal Assistant, Knowledge Graph, AnythingLLM"
-tags: ["ai", "infrastructure", "rag", "nouverse"]
+tags: ["agent-memory", "ai", "infrastructure", "rag", "nouverse"]
 image: "/media/blog/the-graphrag-trap/banner.png"
 ---
 
@@ -61,6 +61,10 @@ Nouva is now faster, the infrastructure is leaner (one less Docker container to 
 If you're building an AI for yourself or a small team, ask yourself: *Do I really need to traverse a graph to remember what I did yesterday?* 
 
 Probably not. Keep it simple. Use RAG for knowledge, and a simple file-based memory for context.
+
+### Related Blogs
+Before getting hit by the harsh reality in this post, here was the start of my experiments when I was still optimistic about GraphRAG:
+* [Building GraphRAG for Autonomous Agents with Neo4J and Graphitti](/blog/building-graphrag-neo4j-graphitti)
 
 ---
 

--- a/src/contents/posts/id/bagaimana-saya-handle-agent-memory-untuk-skala-personal-ai-assistant.mdx
+++ b/src/contents/posts/id/bagaimana-saya-handle-agent-memory-untuk-skala-personal-ai-assistant.mdx
@@ -7,7 +7,7 @@ slug: {
 date: 2026-07-05
 description: "Peta perjalanan saya merombak sistem memori AI Agent Nouva dari yang tadinya berisik dan bikin RAG dilusi, menjadi skema Two-Tier Hybrid RAG + NAS Markdown yang 95% mengcover semua kebutuhan."
 keywords: "AI Agent, Agent Memory, RAG, AnythingLLM, NAS, Markdown, Personal AI Assistant, OpenClaw"
-tags: ["ai", "infrastructure", "rag", "nouverse"]
+tags: ["agent-memory", "ai", "infrastructure", "rag", "nouverse"]
 image: "/media/blog/how-i-handle-agent-memory-for-personal-ai-assistant/banner.png"
 ---
 
@@ -119,6 +119,11 @@ Kembali ke dasar (*back to basics*) dan memahami core concept dari masalah yang 
 Skema flat RAG + NAS ini adalah fondasi awal yang solid. Namun, ketika jumlah catatan harian mulai menumpuk hingga ratusan hari, tantangan berikutnya adalah bagaimana kita mengatasi *index bloating*, *vector dilution*, dan melakukan *graph traversal* (menghubungkan chat yang bersambung antar hari) tanpa mengorbankan performa.
 
 Di tulisan selanjutnya, yaitu **Membangun Agent Memory dengan Vendor Lock-in Resistance (Part 2)**, gw bakal bedah kelanjutan dari arsitektur ini. Kita akan bahas bagaimana merombak sistem memori Nouva menggunakan pendekatan *Hierarchical Summary* dan rumus *Hybrid Scoring* sederhana agar pencarian memori tetap instan, rapi, dan tentu saja, tetap 100% bebas dari vendor lock-in.
+
+### Blog Terkait
+Biar dapet gambaran utuh kenapa gue sampai pada arsitektur memori lokal di tulisan ini, lu bisa baca perjalanan eksperimen gue sebelumnya:
+1. [Membangun GraphRAG untuk Agen Otonom dengan Neo4J and Graphitti](/id/blog/membangun-graphrag-neo4j-graphitti) (Fase awal nyoba GraphRAG)
+2. [Jebakan GraphRAG: Kenapa Gue Akhirnya Uninstall Neo4j](/id/blog/jebakan-graphrag-uninstall-neo4j) (Fase tersadar kalau ini overkill)
 
 ---
 

--- a/src/contents/posts/id/jebakan-graphrag-uninstall-neo4j.mdx
+++ b/src/contents/posts/id/jebakan-graphrag-uninstall-neo4j.mdx
@@ -7,7 +7,7 @@ slug: {
 date: 2026-02-28
 description: "Kenapa GraphRAG seringkali overkill buat asisten AI pribadi dan alasan gw mutusin buat balik ke stack RAG + Memory yang lebih simpel buat Nouva."
 keywords: "GraphRAG, RAG, Neo4j, AI Agent, Personal Assistant, Knowledge Graph, AnythingLLM"
-tags: ["ai", "infrastructure", "rag", "nouverse"]
+tags: ["agent-memory", "ai", "infrastructure", "rag", "nouverse"]
 image: "/media/blog/the-graphrag-trap/banner.png"
 ---
 
@@ -61,6 +61,10 @@ Nouva sekarang jauh lebih cepet, infrastrukturnya lebih enteng (kurang satu cont
 Kalau lu lagi bangun AI buat diri sendiri atau tim kecil, tanya ke diri sendiri: *Emang lu beneran butuh traversal graph cuma buat inget apa yang lu kerjain kemaren?*
 
 Kayaknya nggak. *Keep it simple*. Pake RAG buat *knowledge*, dan pake file-based memory buat konteks.
+
+### Blog Terkait
+Sebelum kebentur kenyataan pahit di tulisan ini, ini awal mula eksperimen gue pas masih optimis-optimisnya nyoba GraphRAG:
+* [Membangun GraphRAG untuk Agen Otonom dengan Neo4J and Graphitti](/id/blog/membangun-graphrag-neo4j-graphitti)
 
 ---
 

--- a/src/contents/posts/id/membangun-agent-memory-bebas-vendor.mdx
+++ b/src/contents/posts/id/membangun-agent-memory-bebas-vendor.mdx
@@ -7,7 +7,7 @@ slug: {
 date: 2026-07-06
 description: "Kelanjutan eksperimen memori AI Agent Nouva: mengatasi index bloat dengan Two-Tier Hierarchical Summary, hybrid scoring (semantic + importance + recency), dan graph link validation."
 keywords: "AI Agent, Agent Memory, RAG, AnythingLLM, Hierarchical Memory, Hybrid Scoring, Obsidian, OpenClaw"
-tags: ["ai", "infrastructure", "rag", "nouverse"]
+tags: ["agent-memory", "ai", "infrastructure", "rag", "nouverse"]
 image: "/media/blog/membangun-agent-memory-bebas-vendor/banner.png"
 ---
 
@@ -157,3 +157,9 @@ Tantangan terakhir adalah data lama yang udah keburu diarsipkan ke NAS sebelum s
 Jadi, apakah akhirnya gw butuh memory stack eksternal yang canggih dan berbayar? Ternyata jawabannya tetap **belum**. Gw masih bisa "ngakalin" approach-nya menggunakan file markdown lokal, sedikit script Python, dan matematika hybrid scoring sederhana untuk disesuaikan dengan kebutuhan riil gw, tanpa harus boros token LLM atau bergantung pada vendor pihak ketiga.
 
 Refactoring ini ngebuktiin kalau dengan struktur folder markdown yang rapi, YAML frontmatter, sedikit matematika hybrid scoring, dan tool visualisasi markdown standar seperti Obsidian, kita udah bisa bikin sistem memori AI Agent yang cerdas, cepat, dan 100% milik kita sendiri.
+
+### Blog Terkait
+Arsitektur memori ini gak lahir dalam semalam. Ini adalah hasil evolusi dari beberapa eksperimen dan kegagalan gue sebelumnya:
+1. [Membangun GraphRAG untuk Agen Otonom dengan Neo4J and Graphitti](/id/blog/membangun-graphrag-neo4j-graphitti) (Awal mula nyoba GraphRAG)
+2. [Jebakan GraphRAG: Kenapa Gue Akhirnya Uninstall Neo4j](/id/blog/jebakan-graphrag-uninstall-neo4j) (Keputusan uninstall karena overkill)
+3. [Bagaimana Saya Membangun Agent Memory yang Bebas Vendor Lock-in](/id/blog/bagaimana-saya-handle-agent-memory-untuk-skala-personal-ai-assistant) (Solusi awal pake flat RAG + NAS)

--- a/src/contents/posts/id/membangun-graphrag-neo4j-graphitti.mdx
+++ b/src/contents/posts/id/membangun-graphrag-neo4j-graphitti.mdx
@@ -7,7 +7,7 @@ slug: {
 date: 2026-02-24
 description: "Cara membangun agen otonom dengan memori jangka panjang menggunakan GraphRAG, Neo4J, dan Graphitti."
 keywords: "RAG, AI Agents, MCP, GraphRAG, Neo4j, Graphiti, Memori Jangka Panjang"
-tags: ["ai", "rag", "mcp", "graphrag"]
+tags: ["agent-memory", "ai", "rag", "mcp", "graphrag"]
 image: "/media/blog/building-graphrag-neo4j-graphitti/banner.png"
 ---
 


### PR DESCRIPTION
This PR adds the new tag 'agent-memory' to the 4 agent memory posts (both ID and EN) and includes 'Related Blogs' / 'Blog Terkait' sections to help readers follow the chronological journey of Gading's agent memory experiments.