### PR TITLE
docs: refine blog description to reflect programmatic 1-hop related dates

### DIFF
--- a/src/contents/posts/en/building-agent-memory-free-vendor.mdx
+++ b/src/contents/posts/en/building-agent-memory-free-vendor.mdx
@@ -5,7 +5,7 @@ slug: {
   id: "membangun-agent-memory-bebas-vendor"
 }
 date: 2026-07-06
-description: "The next step in my AI Agent's memory experiments: solving index bloat with Two-Tier Hierarchical Summary, hybrid scoring (semantic + importance + recency), and graph link validation."
+description: "The next step in my AI Agent's memory experiments: solving index bloat with Two-Tier Hierarchical Summary, hybrid scoring (semantic + importance + recency), and programmatic 1-hop related dates."
 keywords: "AI Agent, Agent Memory, RAG, AnythingLLM, Hierarchical Memory, Hybrid Scoring, Obsidian, OpenClaw"
 tags: ["agent-memory", "ai", "infrastructure", "rag", "nouverse"]
 image: "/media/blog/membangun-agent-memory-bebas-vendor/banner.png"

--- a/src/contents/posts/id/membangun-agent-memory-bebas-vendor.mdx
+++ b/src/contents/posts/id/membangun-agent-memory-bebas-vendor.mdx
@@ -5,7 +5,7 @@ slug: {
   id: "membangun-agent-memory-bebas-vendor"
 }
 date: 2026-07-06
-description: "Kelanjutan eksperimen memori AI Agent Nouva: mengatasi index bloat dengan Two-Tier Hierarchical Summary, hybrid scoring (semantic + importance + recency), dan graph link validation."
+description: "Kelanjutan eksperimen memori AI Agent Nouva: mengatasi index bloat dengan Two-Tier Hierarchical Summary, hybrid scoring (semantic + importance + recency), dan programmatic 1-hop related dates."
 keywords: "AI Agent, Agent Memory, RAG, AnythingLLM, Hierarchical Memory, Hybrid Scoring, Obsidian, OpenClaw"
 tags: ["agent-memory", "ai", "infrastructure", "rag", "nouverse"]
 image: "/media/blog/membangun-agent-memory-bebas-vendor/banner.png"


### PR DESCRIPTION
This PR updates the metadata descriptions of the Part 2 agent memory blog post (both ID and EN) to replace the deprecated 'graph link validation' with 'programmatic 1-hop related dates', ensuring accurate summaries on the website.